### PR TITLE
[bloom] Example of styled button component

### DIFF
--- a/apps/public-sf/pages/listing.tsx
+++ b/apps/public-sf/pages/listing.tsx
@@ -31,6 +31,10 @@ import {
   t,
 } from "@bloom-housing/ui-components"
 import Layout from "../layouts/application"
+import BaseButton from "../src/components/BaseButton"
+import PrimaryButton from "../src/components/PrimaryButton"
+import SecondaryButton from "../src/components/SecondaryButton"
+import BorderlessButton from "../src/components/BorderlessButton"
 
 interface ListingProps {
   listing: Listing
@@ -187,7 +191,48 @@ export default class extends Component<ListingProps> {
           <div className="w-full md:w-2/3 md:mt-3 md:hidden md:mx-3">
             <ApplicationSection listing={listing} />
           </div>
+
           <ListingDetails>
+            <div className="my-1">
+              <BaseButton onClick={(e) => console.log("BaseButton clicked")}>
+                BaseButton
+              </BaseButton>
+            </div>
+            <div className="my-1">
+              <PrimaryButton onClick={(e) => console.log("PrimaryButton clicked")}>
+                Primary
+              </PrimaryButton>
+            </div>
+            <div className="my-1">
+              <SecondaryButton onClick={(e) => console.log("SecondaryButton clicked")}>
+                Secondary
+              </SecondaryButton>
+            </div>
+            <div className="my-1">
+              <BorderlessButton onClick={(e) => console.log("BorderlessButton clicked")}>
+                Borderless
+              </BorderlessButton>
+            </div>
+            <div className="my-1">
+              <BaseButton buttonSize="small" onClick={(e) => console.log("BaseButton clicked")}>
+                BaseButton small
+              </BaseButton>
+            </div>
+            <div className="my-1">
+              <PrimaryButton buttonSize="small" onClick={(e) => console.log("PrimaryButton clicked")}>
+                Primary small
+              </PrimaryButton>
+            </div>
+            <div className="my-1">
+              <SecondaryButton buttonSize="small" onClick={(e) => console.log("SecondaryButton clicked")}>
+                Secondary small
+              </SecondaryButton>
+            </div>
+            <div className="my-1">
+              <BorderlessButton buttonSize="small" onClick={(e) => console.log("BorderlessButton clicked")}>
+                Borderless small
+              </BorderlessButton>
+            </div>
             <ListingDetailItem
               imageAlt="eligibility-notebook"
               imageSrc="/images/listing-eligibility.svg"

--- a/apps/public-sf/src/components/BaseButton.tsx
+++ b/apps/public-sf/src/components/BaseButton.tsx
@@ -1,0 +1,54 @@
+import * as React from "react"
+import tw, { styled } from 'twin.macro'
+
+export type ButtonSize = "default" | "regular" | "small"
+
+export interface ButtonProps {
+  className?: string
+  buttonSize?: ButtonSize
+  children: React.ReactNode
+  onClick?: (e: React.MouseEvent) => void
+}
+
+const defaultProps = {
+  buttonSize: "default",
+} as Partial<ButtonProps>
+
+
+const UnstyledButton = ({ className, children, onClick }: ButtonProps) => (
+  <button
+    className={className}
+    onClick={onClick}
+  >
+    {children}
+  </button>
+)
+
+/*
+ * This should never be used directly in the product, instead, you should use the components
+ * that build off of this, like PrimaryButton or SecondaryButton.
+ */
+const BaseButton = styled(UnstyledButton)<ButtonProps>`
+  ${tw`
+    border-2
+    border-primary
+    rounded
+    px-6
+    py-4
+    text-lg
+    text-center
+    uppercase
+    font-alt-sans
+    inline-block
+    tracking-widest
+    text-sm
+    font-bold
+    leading-snug
+    hover:(bg-primary-dark text-white)
+  `}
+  ${props => props.buttonSize == "small" && tw`text-xs px-6 py-3`}
+`
+
+BaseButton.defaultProps = defaultProps
+
+export { BaseButton as default, BaseButton }

--- a/apps/public-sf/src/components/BorderlessButton.tsx
+++ b/apps/public-sf/src/components/BorderlessButton.tsx
@@ -1,0 +1,15 @@
+import tw, { styled } from 'twin.macro'
+import BaseButton from './BaseButton'
+
+const BorderlessButton = styled(BaseButton)`
+  border-color: transparent;
+  background: transparent;
+
+  &:hover {
+    background: transparent;
+  }
+
+  ${tw`text-primary-dark hover:(text-primary-darker)`}
+`
+
+export { BorderlessButton as default, BorderlessButton }

--- a/apps/public-sf/src/components/PrimaryButton.tsx
+++ b/apps/public-sf/src/components/PrimaryButton.tsx
@@ -1,0 +1,6 @@
+import tw from 'twin.macro'
+import BaseButton from './BaseButton'
+
+const PrimaryButton = tw(BaseButton)`bg-primary-dark text-white hover:bg-primary-darker`
+
+export { PrimaryButton as default, PrimaryButton }

--- a/apps/public-sf/src/components/SecondaryButton.tsx
+++ b/apps/public-sf/src/components/SecondaryButton.tsx
@@ -1,0 +1,6 @@
+import tw from 'twin.macro'
+import BaseButton from './BaseButton'
+
+const SecondaryButton = tw(BaseButton)`bg-white text-primary hover:(bg-primary-dark text-white)`
+
+export { SecondaryButton as default, SecondaryButton }


### PR DESCRIPTION
This PR shows an example styled component using Tailwind, styled-components, and twin.macro.

It follows the pattern of creating one base component with limited styling, and other components that extend it with additional styling and behavior.

This allows us to put a11y features in the base component that will be shared, while still allowing us to re-style components as much as needed.

For components with a couple style variations, they could all go in the same file, but since Buttons have multiple variations, it makes sense to put them in separate files in the same folder.

In production, there should also be a linting rule that makes sure we don't import the base components outside of the ui-components package.

## Why put this component in public-sf instead of ui-components?
It should go in ui-components. I was struggling with using twin.macro in that package though, I think there might be a bug with the interaction of twin.macro and another package that causes tw not to work. This is fixable with more investigation but I just wanted to come up with a proof of concept for this.

![- 2020-08-10 at 1 50 09 PM](https://user-images.githubusercontent.com/64036574/89830240-ba503600-db10-11ea-8bc2-9500ffaf678f.png)